### PR TITLE
Upgrade to Error Prone 2.10.0 and NullAway 0.9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,12 +246,12 @@
                         <path>
                             <groupId>com.google.errorprone</groupId>
                             <artifactId>error_prone_core</artifactId>
-                            <version>2.8.0</version>
+                            <version>2.10.0</version>
                         </path>
                         <path>
                             <groupId>com.uber.nullaway</groupId>
                             <artifactId>nullaway</artifactId>
-                            <version>0.9.1</version>
+                            <version>0.9.2</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>


### PR DESCRIPTION
- https://github.com/google/error-prone/releases/tag/v2.8.1
- https://github.com/google/error-prone/releases/tag/v2.9.0
- https://github.com/google/error-prone/releases/tag/v2.10.0
- https://github.com/uber/NullAway/blob/v0.9.2/CHANGELOG.md#version-092