### PR TITLE
ci: remove 1.2.x, 1.3.x, and 1.4.x as base branch in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,9 +16,6 @@
     "schedule:weekly"
   ],
   "baseBranchPatterns": [
-    "1.2.x",
-    "1.3.x",
-    "1.4.x",
     "1.5.x"
   ],
   "dependencyDashboard": true,


### PR DESCRIPTION
Logback 1.2.x, 1.3.x, and 1.4.x aren't maintained anymore.