### PR TITLE
build: force Javadoc 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -386,6 +386,8 @@
                         <configuration>
                             <doclint>none</doclint>
                             <quiet>true</quiet>
+                            <notimestamp>true</notimestamp>
+                            <javadocVersion>1.8</javadocVersion>
                         </configuration>
                         <executions>
                             <execution>


### PR DESCRIPTION
```
Error:  Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.11.3:jar (attach-javadocs) on project logback-throttling-appender: MavenReportException: Error while generating Javadoc:
Error:  Exit code: 1
Error: [ERROR] error: module io.dropwizard.logback reads package org.jspecify.annotations from both org.jspecify and io.dropwizard.logback
Error: [ERROR] error: the unnamed module reads package org.jspecify.annotations from both io.dropwizard.logback and org.jspecify
Error: [ERROR] 2 errors
Error:  Command line was: /opt/hostedtoolcache/Java_Zulu_jdk/17.0.16-8/x64/bin/javadoc -J-Duser.language= -J-Duser.country= @options @packages
```