### PR TITLE
This shades jspecify, if that is the right choice

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -310,7 +310,7 @@
                                     </excludes>
                                 </filter>
                                 <filter>
-                                    <artifact>org.checkerframework:*</artifact>
+                                    <artifact>org.jspecify:*</artifact>
                                     <excludes>
                                         <exclude>META-INF/**</exclude>
                                     </excludes>
@@ -330,8 +330,8 @@
                                     <shadedPattern>io.dropwizard.logback.shaded.errorprone</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>org.checkerframework</pattern>
-                                    <shadedPattern>io.dropwizard.logback.shaded.checkerframework</shadedPattern>
+                                    <pattern>org.jspecify.annotations</pattern>
+                                    <shadedPattern>io.dropwizard.logback.shaded.jspecify</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>javax.annotation</pattern>


### PR DESCRIPTION
I don't think jspecify should be shaded, but if we should be shading it it can be done with the changes in this PR.

Found and reported from here:
Relates to: https://github.com/dropwizard/dropwizard/issues/10484

I can make a separate PR with this branch if the decision is to stop shading:
https://github.com/JKomoroski/logback-throttling-appender/tree/do_not_shade